### PR TITLE
Allow accounts directory to be user customizable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,6 +108,7 @@ dependencies = [
  "data-encoding 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "open 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.14.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ serde_derive = "1.0"
 open = "1.2.1"
 dirs = "1.0.2"
 failure = "0.1.1"
+lazy_static = "1.3"
 
 [[bin]]
 path = "src/main.rs"

--- a/README.md
+++ b/README.md
@@ -117,6 +117,20 @@ To view the help of any of the subcommands below, add `-h` or `--help`, e.g. `cl
     This will open a file, using your preferred editor, to either save new recovery
     codes or view existing recovery codes.
 
+## Customization
+
+By default `cloak` stores your accounts and recovery codes inside a `.cloak/`
+directory found inside your `$HOME` folder if you are on Linux or macOS, or
+inside your user profile folder if you are on Windows.
+
+To alter this, you can use the `CLOAK_ACCOUNTS_DIR` environment variable to
+point `cloak` to the directory to use for storing your accounts and recovery
+codes:
+
+```bash
+export CLOAK_ACCOUNTS_DIR='/save/accounts/here/'  # absolute path
+```
+
 ## Contributions
 
 If you want to contribute to `cloak` you will have to clone the repository on your

--- a/src/dirs.rs
+++ b/src/dirs.rs
@@ -1,0 +1,38 @@
+use dirs_rs;
+use std::env;
+use std::path::{Path, PathBuf};
+
+pub struct CloakAppDirs {
+    accounts_dir: PathBuf,
+    recovery_codes_dir: PathBuf,
+}
+
+impl CloakAppDirs {
+    fn new() -> Option<CloakAppDirs> {
+        let accounts_dir = env::var("CLOAK_ACCOUNTS_DIR")
+            .ok()
+            .map(PathBuf::from)
+            .filter(|acc_dir| acc_dir.is_absolute())
+            .or_else(|| dirs_rs::home_dir().map(|d| d.join(".cloak/")))?;
+
+        let recovery_codes_dir = accounts_dir.join("recovery_codes/");
+
+        Some(CloakAppDirs {
+            accounts_dir,
+            recovery_codes_dir,
+        })
+    }
+
+    pub fn accounts_dir(&self) -> &Path {
+        &self.accounts_dir
+    }
+
+    pub fn recovery_codes_dir(&self) -> &Path {
+        &self.recovery_codes_dir
+    }
+}
+
+lazy_static! {
+    pub static ref CLOAK_DIRS: CloakAppDirs =
+        CloakAppDirs::new().expect("Could not get cloak's accounts directory");
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -15,9 +15,6 @@ pub enum Error {
         cause: Box<DecodeError>,
     },
 
-    #[fail(display = "HOME_DIR could not be found")]
-    HomeDirNotFound,
-
     #[fail(display = "I/O error: {}", _0)]
     Io(#[cause] io::Error),
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 #[macro_use]
 extern crate clap;
 extern crate data_encoding;
-extern crate dirs;
+extern crate dirs as dirs_rs;
 extern crate open;
 #[macro_use]
 extern crate failure;
@@ -10,10 +10,13 @@ extern crate serde;
 #[macro_use]
 extern crate serde_derive;
 extern crate toml;
+#[macro_use]
+extern crate lazy_static;
 
 use clap::App;
 
 mod cmd;
+mod dirs;
 mod errors;
 mod fs;
 mod otp;


### PR DESCRIPTION
Allow the user to change the directory of the accounts by setting the
`CLOAK_ACCOUNTS_DIR` environment variable.