### PR TITLE
Add workflow to push binaries on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@
 name: Release
 
 on:
+  workflow_dispatch:
   push:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,8 +41,8 @@ jobs:
           # Apparently, this is the right way to get a tag name. Really?
           #
           # See: https://github.community/t5/GitHub-Actions/How-to-get-just-the-tag-name/m-p/32167/highlight/true#M1027
-          echo "CLOAK_VERSION=${GITHUB_REF_NAME}" >> $GITHUB_ENV
-          echo "version is: ${{ env.CLOAK_VERSION }}"
+          echo "CLOAK_VERSION=${{  github.ref_name }}" >> $GITHUB_ENV
+          echo "version is: ${{  github.ref_name }}"
       - name: Create GitHub release
         id: release
         uses: actions/create-release@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
           # Apparently, this is the right way to get a tag name. Really?
           #
           # See: https://github.community/t5/GitHub-Actions/How-to-get-just-the-tag-name/m-p/32167/highlight/true#M1027
-          echo "CLOAK_VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+          echo "CLOAK_VERSION=${GITHUB_REF_NAME}" >> $GITHUB_ENV
           echo "version is: ${{ env.CLOAK_VERSION }}"
       - name: Create GitHub release
         id: release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,6 +109,7 @@ jobs:
         shell: bash
         run: |
           staging="cloak-${{ needs.create-release.outputs.cloak_version }}-${{ matrix.target }}"
+          mkdir "$staging"
           cp {README.md,LICENSE} "$staging/"
 
           if [ "${{ matrix.os }}" = "windows-latest" ]; then


### PR DESCRIPTION
Pushing a tag to master should make the release with the correct tag name now, the method of getting tag name has been updated see [https://docs.github.com/en/actions/learn-github-actions/contexts#github-context](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context)

(In my actions tab it is showing master as i ran it with workflow dispatch, if a tag is pushed, it would use the tag name instead)

Also, Staging directory was not created before using it